### PR TITLE
BUGFIX: Fix depth comparison in hasHiddenNodeParent(…)

### DIFF
--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -237,6 +237,6 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
         $rootNode = $node->getContext()->getRootNode();
         $nodesOnPath = $node->getContext()->getNodesOnPath($rootNode, $node);
 
-        return count($nodesOnPath) < $node->getDepth();
+        return count($nodesOnPath) <= $node->getDepth();
     }
 }


### PR DESCRIPTION
The comparison in this is wrong. Because the depth is 0-based, but the nodes returned by getNodesOnPath(…) contain the root node, less-than-or-equal must be used.

Fixes #3363
